### PR TITLE
fix[testing-code]: fix workflow goodbye_message in

### DIFF
--- a/exercises/testing-code/practice/workflow.py
+++ b/exercises/testing-code/practice/workflow.py
@@ -48,7 +48,7 @@ class TranslationWorkflow:
             goodbye_input,
             start_to_close_timeout=timedelta(seconds=5),
         )
-        goodbye_message = f"{goodbye_result.translation} {input.name}"
+        goodbye_message = f"{goodbye_result.translation}, {input.name}"
 
         return TranslationWorkflowOutput(
             hello_message=hello_message, goodbye_message=goodbye_message


### PR DESCRIPTION
testing-code practice

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
workflow.py in testing-code practive

## Why?
when doing "Test a Workflow Definition" exercise, the tests were not successful
```
- The goodbye_message field in the result is Au revoir, Pierre
``` 
however the workflow returns `Au revoir Pierre` not `Au revoir, Pierre`

## Checklist
- `python -m pytest`
