### PR TITLE
fix Slovak translation

### DIFF
--- a/utilities/microservice/microservice.py
+++ b/utilities/microservice/microservice.py
@@ -14,7 +14,7 @@ translations = {
     "fr": {"hello": "bonjour", "goodbye": "au revoir", "thanks": "merci"},
     "lv": {"hello": "sveiks", "goodbye": "ardievu", "thanks": "paldies"},
     "mi": {"hello": "kia ora", "goodbye": "poroporoaki", "thanks": "whakawhetai koe"},
-    "sk": {"hello": "ahoj", "goodbye": "zbohom", "thanks": "ďakujem koe"},
+    "sk": {"hello": "ahoj", "goodbye": "zbohom", "thanks": "ďakujem"},
     "tr": {"hello": "merhaba", "goodbye": "güle güle", "thanks": "teşekkür ederim"},
     "zu": {"hello": "hamba kahle", "goodbye": "sawubona", "thanks": "ngiyabonga"},
 }


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

I corrected the translation for "thanks" in Slovak in the exercise code.

## Why?
<!-- Tell your future self why have you made these changes -->

As per https://github.com/temporalio/edu-102-typescript-code/pull/54, the existing translation was incorrect. The inclusion of "koe" was a copy-paste error from the Maori translation that preceded the Slovak one. 
